### PR TITLE
Support for multicast address different than default

### DIFF
--- a/examples/search/search.go
+++ b/examples/search/search.go
@@ -6,13 +6,14 @@ import (
 	"log"
 	"os"
 
-	"github.com/koron/go-ssdp"
+	ssdp "github.com/pulento/go-ssdp"
 )
 
 func main() {
 	t := flag.String("t", ssdp.All, "search type")
 	w := flag.Int("w", 1, "wait time")
 	l := flag.String("l", "", "local address to listen")
+	m := flag.String("m", "", "multicast address to send")
 	v := flag.Bool("v", false, "verbose mode")
 	h := flag.Bool("h", false, "show help")
 	flag.Parse()
@@ -23,7 +24,7 @@ func main() {
 	if *v {
 		ssdp.Logger = log.New(os.Stderr, "[SSDP] ", log.LstdFlags)
 	}
-	list, err := ssdp.Search(*t, *w, *l)
+	list, err := ssdp.Search(*t, *w, *l, *m)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/search/search.go
+++ b/examples/search/search.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	ssdp "github.com/pulento/go-ssdp"
+	"github.com/koron/go-ssdp"
 )
 
 func main() {

--- a/search.go
+++ b/search.go
@@ -66,7 +66,7 @@ const (
 )
 
 // Search searchs services by SSDP.
-func Search(searchType string, waitSec int, localAddr string) ([]Service, error) {
+func Search(searchType string, waitSec int, localAddr string, mcastAddr ...string) ([]Service, error) {
 	// dial multicast UDP packet.
 	conn, err := multicastListen(localAddr)
 	if err != nil {
@@ -75,6 +75,13 @@ func Search(searchType string, waitSec int, localAddr string) ([]Service, error)
 	defer conn.Close()
 	logf("search on %s", conn.LocalAddr().String())
 
+	if len(mcastAddr) > 0 && len(mcastAddr[0]) > 0 {
+		var err error
+		ssdpAddrIPv4, err = net.ResolveUDPAddr("udp4", mcastAddr[0])
+		if err != nil {
+			return nil, err
+		}
+	}
 	// send request.
 	msg, err := buildSearch(ssdpAddrIPv4, searchType, waitSec)
 	if err != nil {

--- a/search.go
+++ b/search.go
@@ -124,7 +124,9 @@ func parseService(addr net.Addr, data []byte) (*Service, error) {
 	if !bytes.HasPrefix(data, []byte("HTTP")) {
 		return nil, errWithoutHTTPPrefix
 	}
-	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(data)), nil)
+	// Add newline to workaround buggy SSDP responses
+	str := append(data, "\r\n"...)
+	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(str)), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/search.go
+++ b/search.go
@@ -68,13 +68,6 @@ const (
 // Search searchs services by SSDP.
 func Search(searchType string, waitSec int, localAddr string, mcastAddr ...string) ([]Service, error) {
 	// dial multicast UDP packet.
-	conn, err := multicastListen(localAddr)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-	logf("search on %s", conn.LocalAddr().String())
-
 	if len(mcastAddr) > 0 && len(mcastAddr[0]) > 0 {
 		var err error
 		ssdpAddrIPv4, err = net.ResolveUDPAddr("udp4", mcastAddr[0])
@@ -82,6 +75,14 @@ func Search(searchType string, waitSec int, localAddr string, mcastAddr ...strin
 			return nil, err
 		}
 	}
+
+	conn, err := multicastListen(localAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	logf("search on %s", conn.LocalAddr().String())
+
 	// send request.
 	msg, err := buildSearch(ssdpAddrIPv4, searchType, waitSec)
 	if err != nil {


### PR DESCRIPTION
Some IoT devices like Yeelight lights do SSDP on a different port or multicast group. This PR enables go-ssdp to have an optional parameter on Search() so we can send and listen to a different address.

Also there is a workaround for buggy devices that don't end HTTP headers with an empty line which was causing an EOF on go net/http.