### PR TITLE
Typo prevented to pass the actual parameter

### DIFF
--- a/search.go
+++ b/search.go
@@ -120,7 +120,8 @@ var (
 	errWithoutHTTPPrefix = errors.New("without HTTP prefix")
 )
 
-var newLine = []byte{'\r', '\n'}
+// Actually is a double new line
+var newLine = []byte{'\r', '\n', '\r', '\n'}
 
 func parseService(addr net.Addr, data []byte) (*Service, error) {
 	if !bytes.HasPrefix(data, []byte("HTTP")) {
@@ -129,7 +130,7 @@ func parseService(addr net.Addr, data []byte) (*Service, error) {
 	// Add newline to workaround buggy SSDP responses
 	if !bytes.HasSuffix(data, newLine) {
 		// why we should't use append() for this purpose:
-		//  https://play.golang.org/p/IM1pONW9lqm
+		// https://play.golang.org/p/IM1pONW9lqm
 		data = bytes.Join([][]byte{data, newLine}, nil)
 	}
 	resp, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(data)), nil)

--- a/udp.go
+++ b/udp.go
@@ -54,7 +54,7 @@ func sendTo(to *net.UDPAddr, data []byte) (int, error) {
 
 // SetMulticastSendAddrIPv4 updates a UDP address to send multicast packets.
 func SetMulticastSendAddrIPv4(s string) error {
-	addr, err := net.ResolveUDPAddr("udp4", sendAddrIPv4)
+	addr, err := net.ResolveUDPAddr("udp4", s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Checked your changes and a typo prevented to actually pass the multicast address.

Also a valid HTTP header must end on an empty newline that's why I was adding an extra newline. So we just add the empty line (with a newline) without any checks, or check for two newlines the one after the header and the one corresponding to the empty newline.