### PR TITLE
Handle buggy SSDP messages for monitor case

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -49,7 +49,14 @@ func (m *Monitor) serve() error {
 	return nil
 }
 
+// Actually is a double new line
+var newLine = []byte{'\r', '\n', '\r', '\n'}
+
 func (m *Monitor) handleRaw(addr net.Addr, raw []byte) error {
+	// Add newline to workaround buggy SSDP responses
+	if !bytes.HasSuffix(raw, newLine) {
+		raw = bytes.Join([][]byte{raw, newLine}, nil)
+	}
 	if bytes.HasPrefix(raw, []byte("M-SEARCH ")) {
 		return m.handleSearch(addr, raw)
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -61,7 +61,11 @@ func (m *Monitor) handleRaw(addr net.Addr, raw []byte) error {
 		return m.handleSearch(addr, raw)
 	}
 	if bytes.HasPrefix(raw, []byte("NOTIFY ")) {
-		return m.handleNotify(addr, raw)
+		err := m.handleNotify(addr, raw)
+		if err != nil {
+			logf("error parsing notify: %s", err)
+		}
+		return err
 	}
 	n := bytes.Index(raw, []byte("\r\n"))
 	logf("unexpected method: %q", string(raw[:n]))

--- a/udp.go
+++ b/udp.go
@@ -61,3 +61,13 @@ func SetMulticastSendAddrIPv4(s string) error {
 	ssdpAddrIPv4 = addr
 	return nil
 }
+
+// SetMulticastRecvAddrIPv4 updates multicast address where to receive packets.
+func SetMulticastRecvAddrIPv4(s string) error {
+	_, err := net.ResolveUDPAddr("udp4", s)
+	if err != nil {
+		return err
+	}
+	recvAddrIPv4 = s
+	return nil
+}


### PR DESCRIPTION
Same as previous PR, but this time for monitor. Some clients send NOTIFY without ending with an empty newline. Also add a method to monitor a non-default multicast address for SSDP.

Logging for failed NOTIFY parsing, it probably has to be extended to SEARCH and BYE too.