### PR TITLE
Fix SSDP M-SEARCH responses (missing EXT header)

### DIFF
--- a/advertise.go
+++ b/advertise.go
@@ -129,6 +129,7 @@ func buildOK(st, usn, location, server string, maxAge int) ([]byte, error) {
 	b := new(bytes.Buffer)
 	// FIXME: error should be checked.
 	b.WriteString("HTTP/1.1 200 OK\r\n")
+	fmt.Fprintf(b, "EXT: \r\n")
 	fmt.Fprintf(b, "ST: %s\r\n", st)
 	fmt.Fprintf(b, "USN: %s\r\n", usn)
 	if location != "" {


### PR DESCRIPTION
Hey @koron 

First of all thanks for the library.
In your `Advertiser` implementation (more specifically in `handleRaw()`) you are aborting in case the `MAN` header is different from `ssdp:discover`. This means you're effectively adding support to the  HTTP Extension Framework. When answering such datagrams, the spec says you have to include the `EXT` header in the response (empty):

```
EXT
Required by HTTP Extension Framework. Confirms that the MAN header was understood. (Header only; no value.) `
```

Some UPnP implementations such as libPlatinum skip the http request to the server defined in the Location header in case this header is missing, not adding the device to detected device list.