### PR TITLE
Introduce location handler callback for dynamic M-SEARCH responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ examples.
 ```go
 import "github.com/koron/go-ssdp"
 
+locationHandler := func(originator net.Addr) string {
+    if originator != nil {
+        ssdp.Logger.Printf("Location header handler called in the context of an M-SEARCH from %s", originator.String())
+    }
+    return "http://192.168.0.1:57086/foo.xml"
+}
+
 ad, err := ssdp.Advertise(
     "my:device",                        // send as "ST"
     "unique:id",                        // send as "USN"
-    "http://192.168.0.1:57086/foo.xml", // send as "LOCATION"
+    locationHandler,                    // callback to get the "LOCATION" header
     "go-ssdp sample",                   // send as "SERVER"
     1800)                               // send as "maxAge" in "CACHE-CONTROL"
 if err != nil {

--- a/examples/advertise/advertise.go
+++ b/examples/advertise/advertise.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"net"
 	"os"
 	"os/signal"
 	"time"
@@ -28,7 +29,18 @@ func main() {
 		ssdp.Logger = log.New(os.Stderr, "[SSDP] ", log.LstdFlags)
 	}
 
-	ad, err := ssdp.Advertise(*st, *usn, *loc, *srv, *maxAge)
+	locationHandler := func(originator net.Addr) string {
+		if originator != nil {
+			ssdp.Logger.Printf("Location header handler called in the context of an M-SEARCH from %s", originator.String())
+			// do something with the originator argument to compute the location
+		} else {
+			ssdp.Logger.Printf("Location header handler called in the context of an Alive announcement")
+		}
+		// just returning the location argument
+		return *loc
+	}
+
+	ad, err := ssdp.Advertise(*st, *usn, *srv, *maxAge, locationHandler)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Right now go-ssdp uses a fixed value for the location header in the `Advertise` implementation. 
This works nearly well in situations where the device answering the M-SEARCH SSDP queries has a unique network interface. 

According to the UPnP device architecture:

```
The URL specified in the LOCATION header of the M-SEARCH response must be reachable by the control point to which the
response is directed. 
```

This means that when a device running the advertiser has multiple network interfaces in the multicast group, we have to provide a reachable url for each interface, in the subnet of the device initiating the search, when answering the datagrams.

So in this PR I define a function callback to get the location header that is invoked with the IP address of the device initiating the search as argument. This gives enough room for custom implementations (e.g. get the ip address of the callee, iterate over the interfaces, find to which subnet the ip belongs, get the ipaddress of the interface and send back).

The only drawback of this PR is the fact that `Alive()` for announcements on the multicast group will also have to call the `locationHandler` callback (using `nil` as argument).  Either way, it is possible to use this argument to differentiate between requests coming from a search or for an announcement. We can also take advantage of the callback implementation to provide different reachable urls (per interface) depending on the iteration (e.g. call alive twice, send a different LOCATION per iteration).

The library also provides the freedom to define other advertisers (1 per interface) to do the alive ticks (in adition to the advertiser answering M-SEARCH queries) so I don't see it as a big deal.

Cheers