### PR TITLE
Ignore errcheck TODOs in comment

### DIFF
--- a/advertise.go
+++ b/advertise.go
@@ -116,18 +116,17 @@ func (a *Advertiser) handleRaw(from net.Addr, raw []byte) error {
 
 func buildOK(st, usn, location, server string, maxAge int) ([]byte, error) {
 	b := new(bytes.Buffer)
-	// FIXME: error should be checked.
 	b.WriteString("HTTP/1.1 200 OK\r\n")
-	fmt.Fprintf(b, "EXT: \r\n")
-	fmt.Fprintf(b, "ST: %s\r\n", st)
-	fmt.Fprintf(b, "USN: %s\r\n", usn)
+	_, _ = fmt.Fprintf(b, "EXT: \r\n")
+	_, _ = fmt.Fprintf(b, "ST: %s\r\n", st)
+	_, _ = fmt.Fprintf(b, "USN: %s\r\n", usn)
 	if location != "" {
-		fmt.Fprintf(b, "LOCATION: %s\r\n", location)
+		_, _ = fmt.Fprintf(b, "LOCATION: %s\r\n", location)
 	}
 	if server != "" {
-		fmt.Fprintf(b, "SERVER: %s\r\n", server)
+		_, _ = fmt.Fprintf(b, "SERVER: %s\r\n", server)
 	}
-	fmt.Fprintf(b, "CACHE-CONTROL: max-age=%d\r\n", maxAge)
+	_, _ = fmt.Fprintf(b, "CACHE-CONTROL: max-age=%d\r\n", maxAge)
 	b.WriteString("\r\n")
 	return b.Bytes(), nil
 }

--- a/announce.go
+++ b/announce.go
@@ -31,19 +31,18 @@ func AnnounceAlive(nt, usn, location, server string, maxAge int, localAddr strin
 
 func buildAlive(raddr net.Addr, nt, usn, location, server string, maxAge int) ([]byte, error) {
 	b := new(bytes.Buffer)
-	// FIXME: error should be checked.
 	b.WriteString("NOTIFY * HTTP/1.1\r\n")
-	fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
-	fmt.Fprintf(b, "NT: %s\r\n", nt)
-	fmt.Fprintf(b, "NTS: %s\r\n", "ssdp:alive")
-	fmt.Fprintf(b, "USN: %s\r\n", usn)
+	_, _ = fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
+	_, _ = fmt.Fprintf(b, "NT: %s\r\n", nt)
+	_, _ = fmt.Fprintf(b, "NTS: %s\r\n", "ssdp:alive")
+	_, _ = fmt.Fprintf(b, "USN: %s\r\n", usn)
 	if location != "" {
-		fmt.Fprintf(b, "LOCATION: %s\r\n", location)
+		_, _ = fmt.Fprintf(b, "LOCATION: %s\r\n", location)
 	}
 	if server != "" {
-		fmt.Fprintf(b, "SERVER: %s\r\n", server)
+		_, _ = fmt.Fprintf(b, "SERVER: %s\r\n", server)
 	}
-	fmt.Fprintf(b, "CACHE-CONTROL: max-age=%d\r\n", maxAge)
+	_, _ = fmt.Fprintf(b, "CACHE-CONTROL: max-age=%d\r\n", maxAge)
 	b.WriteString("\r\n")
 	return b.Bytes(), nil
 }
@@ -73,12 +72,11 @@ func AnnounceBye(nt, usn, localAddr string) error {
 
 func buildBye(raddr net.Addr, nt, usn string) ([]byte, error) {
 	b := new(bytes.Buffer)
-	// FIXME: error should be checked.
 	b.WriteString("NOTIFY * HTTP/1.1\r\n")
-	fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
-	fmt.Fprintf(b, "NT: %s\r\n", nt)
-	fmt.Fprintf(b, "NTS: %s\r\n", "ssdp:byebye")
-	fmt.Fprintf(b, "USN: %s\r\n", usn)
+	_, _ = fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
+	_, _ = fmt.Fprintf(b, "NT: %s\r\n", nt)
+	_, _ = fmt.Fprintf(b, "NTS: %s\r\n", "ssdp:byebye")
+	_, _ = fmt.Fprintf(b, "USN: %s\r\n", usn)
 	b.WriteString("\r\n")
 	return b.Bytes(), nil
 }

--- a/search.go
+++ b/search.go
@@ -110,12 +110,11 @@ func Search(searchType string, waitSec int, localAddr string) ([]Service, error)
 
 func buildSearch(raddr net.Addr, searchType string, waitSec int) ([]byte, error) {
 	b := new(bytes.Buffer)
-	// FIXME: error should be checked.
 	b.WriteString("M-SEARCH * HTTP/1.1\r\n")
-	fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
-	fmt.Fprintf(b, "MAN: %q\r\n", "ssdp:discover")
-	fmt.Fprintf(b, "MX: %d\r\n", waitSec)
-	fmt.Fprintf(b, "ST: %s\r\n", searchType)
+	_, _ = fmt.Fprintf(b, "HOST: %s\r\n", raddr.String())
+	_, _ = fmt.Fprintf(b, "MAN: %q\r\n", "ssdp:discover")
+	_, _ = fmt.Fprintf(b, "MX: %d\r\n", waitSec)
+	_, _ = fmt.Fprintf(b, "ST: %s\r\n", searchType)
 	b.WriteString("\r\n")
 	return b.Bytes(), nil
 }


### PR DESCRIPTION
There's no need to handle err on `fmt.Fprintf`, since `buffer.Write` always returns nil err.

```go
// Fprintf formats according to a format specifier and writes to w.
// It returns the number of bytes written and any write error encountered.
func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
	p := newPrinter()
	p.doPrintf(format, a)
	n, err = w.Write(p.buf)
	p.free()
	return
}
```

```go
// Write appends the contents of p to the buffer, growing the buffer as
// needed. The return value n is the length of p; err is always nil. If the
// buffer becomes too large, Write will panic with ErrTooLarge.
func (b *Buffer) Write(p []byte) (n int, err error) {
	b.lastRead = opInvalid
	m, ok := b.tryGrowByReslice(len(p))
	if !ok {
		m = b.grow(len(p))
	}
	return copy(b.buf[m:], p), nil
}
```